### PR TITLE
Add per-post view counter (Cloudflare Pages Function + KV)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 dist/
 # generated types
 .astro/
+# wrangler / miniflare local state
+.wrangler/
 
 # dependencies
 node_modules/

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "satori-html": "^0.3.2",
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250110.0",
         "@types/bun": "^1.3.14",
         "@types/node": "^25.5.0",
         "@types/prompts": "^2.4.9",
@@ -47,6 +48,8 @@
     "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260702.1", "", {}, "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 

--- a/functions/api/views/[slug].ts
+++ b/functions/api/views/[slug].ts
@@ -1,0 +1,55 @@
+/// <reference types="@cloudflare/workers-types" />
+// functions/api/views/[slug].ts
+//
+// Per-post view counter backed by Workers KV.
+//   GET  /api/views/:slug  -> read the current count (no increment)
+//   POST /api/views/:slug  -> increment and return the new count
+//
+// The KV namespace is bound as `VIEWS` (see wrangler.jsonc / Pages settings).
+
+interface Env {
+  VIEWS: KVNamespace;
+}
+
+const SLUG_RE = /^[a-z0-9_-]{1,100}$/;
+
+const json = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      // Never let the edge cache serve a stale count or suppress the POST.
+      'Cache-Control': 'no-store',
+    },
+  });
+
+const normalizeSlug = (raw: string | string[] | undefined): string | null => {
+  const slug = Array.isArray(raw) ? raw[0] : raw;
+  if (!slug || !SLUG_RE.test(slug)) return null;
+  return slug;
+};
+
+const readCount = async (env: Env, slug: string): Promise<number> => {
+  const value = await env.VIEWS.get(slug);
+  const n = value ? Number.parseInt(value, 10) : 0;
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+};
+
+export const onRequestGet: PagesFunction<Env> = async ({ params, env }) => {
+  const slug = normalizeSlug(params.slug);
+  if (!slug) return json({ error: 'invalid slug' }, 400);
+
+  const count = await readCount(env, slug);
+  return json({ count });
+};
+
+export const onRequestPost: PagesFunction<Env> = async ({ params, env }) => {
+  const slug = normalizeSlug(params.slug);
+  if (!slug) return json({ error: 'invalid slug' }, 400);
+
+  // Read-modify-write. KV is eventually consistent and this is not atomic, so a
+  // few counts can be lost under heavy concurrency — acceptable for this blog.
+  const count = (await readCount(env, slug)) + 1;
+  await env.VIEWS.put(slug, String(count));
+  return json({ count });
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
+    "cf-dev": "wrangler pages dev ./dist",
     "astro": "astro"
   },
   "dependencies": {
@@ -22,6 +23,7 @@
     "satori-html": "^0.3.2"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250110.0",
     "@types/bun": "^1.3.14",
     "@types/node": "^25.5.0",
     "@types/prompts": "^2.4.9",

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -63,6 +63,11 @@ const url = new URL(Astro.url.pathname, Astro.site).href;
           ))}
         </div>
       )}
+      <span class="post-views" data-slug={slug} hidden>
+        <span class="post-views__icon" aria-hidden="true">👁</span>
+        <span class="post-views__n"></span>
+        <span class="post-views__label"> views</span>
+      </span>
     </div>
     {tocHeadings.length > 0 && (
       <details class="toc">
@@ -149,6 +154,46 @@ const url = new URL(Astro.url.pathname, Astro.site).href;
           resetTimer = window.setTimeout(resetLabel, 2000);
         });
       }
+    </script>
+
+    <script is:inline>
+      (() => {
+        // ── view counter ──────────────────────────────────
+        const el = document.querySelector('.post-views');
+        const slug = el?.dataset.slug;
+        if (!el || !slug) return;
+
+        // Count a visitor at most once per post per 24h.
+        const key = 'viewed:' + slug;
+        const DAY = 24 * 60 * 60 * 1000;
+        let firstVisit = true;
+        try {
+          const last = Number(localStorage.getItem(key));
+          firstVisit = !last || Date.now() - last > DAY;
+        } catch {
+          // localStorage unavailable (private mode) → treat as a read.
+          firstVisit = false;
+        }
+
+        fetch('/api/views/' + encodeURIComponent(slug), {
+          method: firstVisit ? 'POST' : 'GET',
+        })
+          .then((res) => (res.ok ? res.json() : Promise.reject()))
+          .then((data) => {
+            if (typeof data?.count !== 'number') return;
+            const n = el.querySelector('.post-views__n');
+            if (n) n.textContent = data.count.toLocaleString('ja-JP');
+            el.hidden = false;
+            if (firstVisit) {
+              try {
+                localStorage.setItem(key, String(Date.now()));
+              } catch {}
+            }
+          })
+          .catch(() => {
+            // Best-effort: leave the counter hidden, page is unaffected.
+          });
+      })();
     </script>
 
     <script is:inline>

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -40,6 +40,22 @@
       margin-right: 0.15rem;
     }
   }
+
+  .post-views {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-variant-numeric: tabular-nums;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  .post-views__icon {
+    font-size: 0.85em;
+    opacity: 0.8;
+  }
 }
 
 :root.dark .prose .post-meta {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,19 @@
+{
+  // Cloudflare Pages config for the blog.
+  // The KV binding `VIEWS` backs the per-post view counter
+  // (functions/api/views/[slug].ts).
+  //
+  // Replace the ids below with the namespace ids from:
+  //   Cloudflare dashboard -> Workers & Pages -> KV -> Create namespace
+  // and also add the same `VIEWS` binding in the Pages project settings
+  // (Settings -> Functions -> KV namespace bindings) for Production + Preview.
+  "name": "blog",
+  "pages_build_output_dir": "./dist",
+  "kv_namespaces": [
+    {
+      "binding": "VIEWS",
+      "id": "<REPLACE_WITH_PROD_KV_NAMESPACE_ID>",
+      "preview_id": "<REPLACE_WITH_PREVIEW_KV_NAMESPACE_ID>"
+    }
+  ]
+}


### PR DESCRIPTION
Static site had no backend, so counts are stored in Workers KV via a
Pages Function at /api/views/:slug (GET reads, POST increments). Each
visitor increments a post at most once per 24h (localStorage guard).
The count renders in the post meta row and stays hidden until loaded.

Requires a KV namespace bound as VIEWS in the Pages project (see
wrangler.jsonc).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LknhF21bJzz6KzzkyK23Uh