### PR TITLE
Move view-counter dedup server-side (unique per visitor per day)

### DIFF
--- a/functions/api/views/[slug].ts
+++ b/functions/api/views/[slug].ts
@@ -1,18 +1,31 @@
 /// <reference types="@cloudflare/workers-types" />
 // functions/api/views/[slug].ts
 //
-// Per-post view counter backed by Workers KV.
+// Per-post view counter backed by Workers KV, with server-side dedup.
 //   GET  /api/views/:slug  -> read the current count (no increment)
-//   POST /api/views/:slug  -> increment and return the new count
+//   POST /api/views/:slug  -> count a unique visit and return the count
+//
+// A visit is deduped per (IP + User-Agent + UTC day): a given visitor
+// increments a post at most once per calendar day (Plausible/GoatCounter
+// style). Raw IP/UA are never stored — only a salted SHA-256 hash.
 //
 // The KV namespace is bound as `VIEWS`, declared in wrangler.jsonc under
-// `kv_namespaces` (generate it with `bun run kv:setup`).
+// `kv_namespaces` (generate it with `bun run kv:setup`). Optional secret
+// `VIEWS_SALT` hardens the visitor hash.
 
 interface Env {
   VIEWS: KVNamespace;
+  VIEWS_SALT?: string;
 }
 
 const SLUG_RE = /^[a-z0-9_-]{1,100}$/;
+
+// Keep the dedup marker a bit longer than a day so day-boundary races don't
+// double count; the UTC day is already baked into the hash.
+const DEDUP_TTL_SECONDS = 60 * 60 * 48;
+
+const countKey = (slug: string) => `count:${slug}`;
+const seenKey = (slug: string, visitor: string) => `seen:${slug}:${visitor}`;
 
 const json = (data: unknown, status = 200): Response =>
   new Response(JSON.stringify(data), {
@@ -31,9 +44,31 @@ const normalizeSlug = (raw: string | string[] | undefined): string | null => {
 };
 
 const readCount = async (env: Env, slug: string): Promise<number> => {
-  const value = await env.VIEWS.get(slug);
+  const value = await env.VIEWS.get(countKey(slug));
   const n = value ? Number.parseInt(value, 10) : 0;
   return Number.isFinite(n) && n >= 0 ? n : 0;
+};
+
+const sha256hex = async (input: string): Promise<string> => {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+// Per-day, per-visitor fingerprint. Includes the UTC date so the hash rotates
+// daily (calendar-day unique); stores only the hash, never the raw IP/UA.
+const visitorHash = async (
+  request: Request,
+  env: Env,
+  slug: string,
+): Promise<string> => {
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const ua = request.headers.get('User-Agent') || '';
+  const day = new Date().toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+  const salt = env.VIEWS_SALT ?? '';
+  return sha256hex(`${day}|${ip}|${ua}|${slug}|${salt}`);
 };
 
 export const onRequestGet: PagesFunction<Env> = async ({ params, env }) => {
@@ -44,13 +79,26 @@ export const onRequestGet: PagesFunction<Env> = async ({ params, env }) => {
   return json({ count });
 };
 
-export const onRequestPost: PagesFunction<Env> = async ({ params, env }) => {
+export const onRequestPost: PagesFunction<Env> = async ({
+  params,
+  env,
+  request,
+}) => {
   const slug = normalizeSlug(params.slug);
   if (!slug) return json({ error: "invalid slug" }, 400);
 
-  // Read-modify-write. KV is eventually consistent and this is not atomic, so a
-  // few counts can be lost under heavy concurrency — acceptable for this blog.
+  const marker = seenKey(slug, await visitorHash(request, env, slug));
+
+  // Already counted this visitor today → return the current value unchanged.
+  if (await env.VIEWS.get(marker)) {
+    return json({ count: await readCount(env, slug), counted: false });
+  }
+
+  // First view today: record the marker (auto-expires), then increment.
+  // Read-modify-write is not atomic, so a few counts can be lost under heavy
+  // concurrency — acceptable here, and dedup keeps write volume low.
+  await env.VIEWS.put(marker, '1', { expirationTtl: DEDUP_TTL_SECONDS });
   const count = (await readCount(env, slug)) + 1;
-  await env.VIEWS.put(slug, String(count));
-  return json({ count });
+  await env.VIEWS.put(countKey(slug), String(count));
+  return json({ count, counted: true });
 };

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -162,32 +162,16 @@ const url = new URL(Astro.url.pathname, Astro.site).href;
         const slug = el?.dataset.slug;
         if (!el || !slug) return;
 
-        // Count a visitor at most once per post per 24h.
-        const key = 'viewed:' + slug;
-        const DAY = 24 * 60 * 60 * 1000;
-        let firstVisit = true;
-        try {
-          const last = Number(localStorage.getItem(key));
-          firstVisit = !last || Date.now() - last > DAY;
-        } catch {
-          // localStorage unavailable (private mode) → treat as a read.
-          firstVisit = false;
-        }
-
-        fetch('/api/views/' + encodeURIComponent(slug), {
-          method: firstVisit ? 'POST' : 'GET',
-        })
+        // Always POST; the server dedups per visitor per day and returns the
+        // count either way. (No request lands on `astro dev`, which has no
+        // Function — the counter simply stays hidden there.)
+        fetch('/api/views/' + encodeURIComponent(slug), { method: 'POST' })
           .then((res) => (res.ok ? res.json() : Promise.reject()))
           .then((data) => {
             if (typeof data?.count !== 'number') return;
             const n = el.querySelector('.post-views__n');
             if (n) n.textContent = data.count.toLocaleString('ja-JP');
             el.hidden = false;
-            if (firstVisit) {
-              try {
-                localStorage.setItem(key, String(Date.now()));
-              } catch {}
-            }
           })
           .catch(() => {
             // Best-effort: leave the counter hidden, page is unaffected.


### PR DESCRIPTION
## Summary

Follow-up to #18. The initial view counter deduped views only on the client via `localStorage`, which is per-browser and trivially bypassable (e.g. `curl -X POST` in a loop). This moves duplicate suppression to the server (Pages Function + KV) and adopts the calendar-day unique model used by Plausible/GoatCounter.

## Changes

- **`functions/api/views/[slug].ts`** — `POST` now dedups per visitor per UTC day:
  - Computes `sha256(day | IP | User-Agent | slug | VIEWS_SALT)` using the Cloudflare-provided `CF-Connecting-IP`. Only the hash is stored — never the raw IP/UA.
  - If a `seen:<slug>:<hash>` marker exists → returns the current count unchanged (`counted: false`); otherwise records the marker (auto-expires after 48h) and increments (`counted: true`).
  - Counter keys are namespaced as `count:<slug>`, dedup markers as `seen:<slug>:<hash>`.
  - Optional `VIEWS_SALT` env var hardens the hash against IP reversal; works unset.
- **`src/layouts/BlogPost.astro`** — drops the `localStorage` guard and always `POST`s, letting the server be the source of truth. Counter still stays hidden on failure (and on `astro dev`, which has no Function).

## Behavior

- Calendar-day reset (UTC), matching Plausible/GoatCounter.
- Reloads and same-IP+UA replays no longer inflate the count.
- Raw IP/UA are not persisted (hash only) → no PII stored.
- KV write volume drops to roughly one write per unique visitor per day.

## Verification

Ran `bun run build` (passes) and exercised the Function locally via `wrangler pages dev ./dist --kv VIEWS`:

- `POST /api/views/vim` → `{"count":1,"counted":true}`
- same UA again → `{"count":1,"counted":false}` (deduped)
- different UA → `{"count":2,"counted":true}`
- `GET /api/views/vim` → read-only, unchanged
- invalid slug → `400`

## Notes

- Read-modify-write on KV remains non-atomic; a few counts can be lost under heavy concurrent first-views. Acceptable here; D1 / Durable Objects are the upgrade path if exact counts are ever needed.
- Same IP+UA behind NAT collapses multiple real users into one count (standard privacy-friendly trade-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LknhF21bJzz6KzzkyK23Uh)_