### PR TITLE
feat(views): make view counter a build-time toggle

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -30,6 +30,8 @@ const tocHeadings = headings.filter(
   (heading) => heading.depth >= 2 && heading.depth <= 3,
 );
 const url = new URL(Astro.url.pathname, Astro.site).href;
+// 環境変数は文字列。"true" のときだけ有効。デフォルト（未設定）は無効。
+const showViews = import.meta.env.PUBLIC_VIEW_COUNTER === "true";
 ---
 
 <MainLayout
@@ -80,10 +82,14 @@ const url = new URL(Astro.url.pathname, Astro.site).href;
           rel="noopener noreferrer">html</a
         >
       </span>
-      <span class="post-views" data-slug={slug} hidden>
-        <span class="post-views__n"></span>
-        <span class="post-views__label"> views</span>
-      </span>
+      {
+        showViews && (
+          <span class="post-views" data-slug={slug} hidden>
+            <span class="post-views__n" />
+            <span class="post-views__label"> views</span>
+          </span>
+        )
+      }
     </div>
     {
       tocHeadings.length > 0 && (
@@ -178,29 +184,33 @@ const url = new URL(Astro.url.pathname, Astro.site).href;
     }
   </script>
 
-  <script is:inline>
-    (() => {
-      // ── view counter ──────────────────────────────────
-      const el = document.querySelector(".post-views");
-      const slug = el?.dataset.slug;
-      if (!el || !slug) return;
+  {
+    showViews && (
+      <script is:inline>
+        (() => {
+          // ── view counter ──────────────────────────────────
+          const el = document.querySelector(".post-views");
+          const slug = el?.dataset.slug;
+          if (!el || !slug) return;
 
-      // Always POST; the server dedups per visitor per day and returns the
-      // count either way. (No request lands on `astro dev`, which has no
-      // Function — the counter simply stays hidden there.)
-      fetch("/api/views/" + encodeURIComponent(slug), { method: "POST" })
-        .then((res) => (res.ok ? res.json() : Promise.reject()))
-        .then((data) => {
-          if (typeof data?.count !== "number") return;
-          const n = el.querySelector(".post-views__n");
-          if (n) n.textContent = data.count.toLocaleString("ja-JP");
-          el.hidden = false;
-        })
-        .catch(() => {
-          // Best-effort: leave the counter hidden, page is unaffected.
-        });
-    })();
-  </script>
+          // Always POST; the server dedups per visitor per day and returns the
+          // count either way. (No request lands on `astro dev`, which has no
+          // Function — the counter simply stays hidden there.)
+          fetch("/api/views/" + encodeURIComponent(slug), { method: "POST" })
+            .then((res) => (res.ok ? res.json() : Promise.reject()))
+            .then((data) => {
+              if (typeof data?.count !== "number") return;
+              const n = el.querySelector(".post-views__n");
+              if (n) n.textContent = data.count.toLocaleString("ja-JP");
+              el.hidden = false;
+            })
+            .catch(() => {
+              // Best-effort: leave the counter hidden, page is unaffected.
+            });
+        })();
+      </script>
+    )
+  }
 
   <script is:inline>
     (() => {


### PR DESCRIPTION
Gate the view counter's markup and inline fetch script in BlogPost.astro
behind a build-time flag read from `import.meta.env.PUBLIC_VIEW_COUNTER`.

When the flag is not "true" (the default), neither the `.post-views`
markup nor the `/api/views` fetch script is emitted into the built HTML,
so disabled builds ship no counter code at all. The backend Pages
Function and KV binding are left untouched and simply go dormant.

To keep the counter enabled (e.g. in production), set
`PUBLIC_VIEW_COUNTER=true` in the build environment.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019cwrYuHtkeVrZJ262uRvxr